### PR TITLE
hotfix: tweaks for firefox

### DIFF
--- a/components/BackgroundImage/BackgroundImage.module.scss
+++ b/components/BackgroundImage/BackgroundImage.module.scss
@@ -32,3 +32,9 @@ $backgroundImage-blur: 30px;
     opacity: var(--backgroundImage-tint-opacity);
   }
 }
+
+@supports not (backdrop-filter: blur(1px)) {
+  .root {
+    --backgroundImage-tint-opacity: 0.9;
+  }
+}

--- a/components/BackgroundImage/BackgroundImage.module.scss
+++ b/components/BackgroundImage/BackgroundImage.module.scss
@@ -34,7 +34,8 @@ $backgroundImage-blur: 30px;
 }
 
 @supports not (backdrop-filter: blur(1px)) {
-  .root {
-    --backgroundImage-tint-opacity: 0.9;
+  .image {
+    transform: scale(1.5);
+    filter: blur(calc(var(--backgroundImage-blur) * 0.6));
   }
 }

--- a/components/BackgroundImage/BackgroundImage.tsx
+++ b/components/BackgroundImage/BackgroundImage.tsx
@@ -21,6 +21,7 @@ const BackgroundImage: React.FC<IBackgroundImageProps> = ({
   <div className={clsx(className, styles.root)}>
     <ThemeVars theme="BackgroundImage" cssProps={styles} />
     <PrxImage
+      className={styles.image}
       src={imageUrl}
       layout="fill"
       objectFit="cover"

--- a/components/Player/CoverArt/CoverArt.tsx
+++ b/components/Player/CoverArt/CoverArt.tsx
@@ -20,12 +20,13 @@ const CoverArt: React.FC<ICoverArtProps> = () => {
     imageUrl: defaultImageUrl
   } = useContext(PlayerContext);
   const imageRef = useRef({ complete: false });
-  const [isLoading, setIsLoading] = useState(true);
+  const isInitialLoad = useRef(true);
+  const [isLoading, setIsLoading] = useState(false);
   const { tracks, currentTrackIndex } = state;
   const { imageUrl, title } = tracks[currentTrackIndex] || ({} as IAudioData);
   const srcUrl = imageUrl || defaultImageUrl;
   const rootClassNames = clsx(styles.root, {
-    [styles.loaded]: !isLoading || imageRef.current.complete
+    [styles.loaded]: !isLoading
   });
 
   const handleClick = () => {
@@ -37,7 +38,10 @@ const CoverArt: React.FC<ICoverArtProps> = () => {
   }, []);
 
   useEffect(() => {
-    setIsLoading(true);
+    if (!isInitialLoad.current) {
+      setIsLoading(true);
+    }
+    isInitialLoad.current = false;
   }, [srcUrl]);
 
   return (

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -227,9 +227,15 @@ const Player: React.FC<IPlayerProps> = ({
   );
 
   const startPlaying = useCallback(() => {
-    audioElm.current.play().then(() => {
-      updateMediaSession();
-    });
+    audioElm.current
+      .play()
+      .then(() => {
+        updateMediaSession();
+      })
+      .catch((e) => {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      });
   }, [updateMediaSession]);
 
   const pauseAudio = useCallback(() => {

--- a/components/Player/PlayerThumbnail/PlayerThumbnail.tsx
+++ b/components/Player/PlayerThumbnail/PlayerThumbnail.tsx
@@ -24,6 +24,7 @@ const PlayerThumbnail: React.FC<IPlayerThumbnailProps> = ({
   ...props
 }) => {
   const imageRef = useRef({ complete: false });
+  const isInitialLoad = useRef(true);
   const { state, imageUrl: defaultImageUrl } = useContext(PlayerContext);
   const [isLoading, setIsLoading] = useState(false);
   const { tracks, currentTrackIndex } = state;
@@ -38,7 +39,10 @@ const PlayerThumbnail: React.FC<IPlayerThumbnailProps> = ({
   }, []);
 
   useEffect(() => {
-    setIsLoading(true);
+    if (!isInitialLoad.current) {
+      setIsLoading(true);
+    }
+    isInitialLoad.current = false;
   }, [srcUrl]);
 
   return (

--- a/components/Player/Playlist/Playlist.module.scss
+++ b/components/Player/Playlist/Playlist.module.scss
@@ -97,6 +97,7 @@ $playlist-header-icon-color--active: colors.$white;
   grid-template-columns: var(--playlist-thumbnail-size) 1fr min-content;
   grid-gap: $padding-h;
   align-items: center;
+  overflow: hidden;
 
   padding: $padding-v $padding-h;
 

--- a/pages/embed.tsx
+++ b/pages/embed.tsx
@@ -34,6 +34,7 @@ import ForwardButton from '@components/Player/ForwardButton';
 import NextButton from '@components/Player/NextButton';
 import Player from '@components/Player';
 import PlayerText from '@components/Player/PlayerText';
+import PlayerThumbnail from '@components/Player/PlayerThumbnail';
 import PreviousButton from '@components/Player/PreviousButton';
 import ReplayButton from '@components/Player/ReplayButton';
 import MoreHorizIcon from '@svg/icons/MoreHoriz.svg';
@@ -49,9 +50,7 @@ const PrxLogoColor = dynamic(
   () => import('@svg/PRX-Logo-Horizontal-Color.svg')
 );
 const CoverArt = dynamic(() => import('@components/Player/CoverArt'));
-const PlayerThumbnail = dynamic(
-  () => import('@components/Player/PlayerThumbnail')
-);
+
 const Playlist = dynamic(() => import('@components/Player/Playlist/Playlist'));
 
 export interface IEmbedPageProps extends IPageProps {
@@ -208,10 +207,8 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
    * Initialize layout breakpoints.
    */
   useEffect(() => {
-    setTimeout(() => {
-      initLayoutBreakpoints();
-      updatePlayerLayout();
-    }, 500);
+    initLayoutBreakpoints();
+    updatePlayerLayout();
   }, [initLayoutBreakpoints, canShowCoverArt, updatePlayerLayout]);
 
   /**
@@ -401,13 +398,15 @@ const EmbedPage = ({ config, data }: IEmbedPageProps) => {
                 </div>
               )}
 
-              <div
-                className={styles.modals}
-                id="embed-modals"
-                {...(!modalShown && {
-                  inert: 'inert'
-                })}
-              />
+              {modalShown && (
+                <div
+                  className={styles.modals}
+                  id="embed-modals"
+                  {...(!modalShown && {
+                    inert: 'inert'
+                  })}
+                />
+              )}
             </Player>
           )}
         </div>


### PR DESCRIPTION

- background image tint darker when backdrop blur not supported
- remove content flash on load
- catch audio play errors
- playlist highlight contained to tack button
- modal container not rendered till modal shown

## To Review

- [ ] Checkout Branch.
- [ ] Run `nvm use`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Use Firefox to go to http://localhost:3000/e?uf=http://feed.songexploder.net/SongExploder&sp=10.

> ...then...

- [ ] Ensure player controls can be interacted with.
- [ ] Ensure content flash is minimal (should no longer take half a second for controls to appear after background.)
- [ ] Though the background image isn't blurred, the contrast should be improved.
- [ ] Ensure active track highlight doesn't bleed out of track button.
- [ ] Switching tracks quickly should no longer trigger an error overlay when error occurs when audio src is changed before previous load was complete. You should see a console error instead.
