### PR TITLE
81: Don't fire hotkey events when modifier keys are pressed

### DIFF
--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -281,6 +281,12 @@ const Player: React.FC<IPlayerProps> = ({
   const handleHotkey = useCallback(
     (event: KeyboardEventWithTarget) => {
       const key = event.code || event.key;
+      const hasModifier =
+        event.altKey || event.shiftKey || event.ctrlKey || event.metaKey;
+
+      // Bail if modifier key is pressed to allow browser shortcuts to function.
+      if (hasModifier) return;
+
       switch (key) {
         case 'KeyS':
           audioElm.current.playbackRate = 3 - audioElm.current.playbackRate;


### PR DESCRIPTION
Closes #81

- Hotkeys will not trigger actions when modifier keys are also pressed.

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:4300/e?uf=https%3A%2F%2Ffeeds.feedburner.com%2FKellyCorriganWonders

> ...then...

- [ ] Press `L`.
- [ ] Progress bar should advance by 10 seconds.
- [ ] Press `CMD + L`.
- [ ] Browser location bar should become focused without advancing the progress bar.
