### PR TITLE
86: Better RSS proxy error handling

### DIFF
--- a/interfaces/error/IPageError.ts
+++ b/interfaces/error/IPageError.ts
@@ -1,0 +1,8 @@
+/**
+ * Defines interfaces for page errors.
+ */
+
+export interface IPageError {
+  statusCode: number;
+  message: string;
+}

--- a/interfaces/error/index.ts
+++ b/interfaces/error/index.ts
@@ -1,1 +1,2 @@
+export * from './IPageError';
 export * from './IRssProxyError';

--- a/interfaces/page/IEmbedPageProps.ts
+++ b/interfaces/page/IEmbedPageProps.ts
@@ -1,0 +1,8 @@
+import { IEmbedConfig } from '@interfaces/config';
+import { IEmbedData } from '@interfaces/data';
+import { IPageProps } from './IPageProps';
+
+export interface IEmbedPageProps extends IPageProps {
+  config: IEmbedConfig;
+  data: IEmbedData;
+}

--- a/interfaces/page/IListenPageProps.ts
+++ b/interfaces/page/IListenPageProps.ts
@@ -1,7 +1,8 @@
 import { IListenConfig } from '@interfaces/config';
 import { IListenData } from '@interfaces/data';
+import { IPageProps } from './IPageProps';
 
-export interface IListenPageProps {
+export interface IListenPageProps extends IPageProps {
   config: IListenConfig;
   data: IListenData;
 }

--- a/interfaces/page/IPageProps.ts
+++ b/interfaces/page/IPageProps.ts
@@ -1,5 +1,7 @@
 import { IEmbedConfig } from '@interfaces/config';
+import { IPageError } from '@interfaces/error';
 
 export interface IPageProps {
   config: IEmbedConfig;
+  error?: IPageError;
 }

--- a/interfaces/page/index.ts
+++ b/interfaces/page/index.ts
@@ -1,2 +1,3 @@
+export * from './IEmbedPageProps';
 export * from './IListenPageProps';
 export * from './IPageProps';

--- a/lib/parse/data/parseEmbedData.ts
+++ b/lib/parse/data/parseEmbedData.ts
@@ -79,16 +79,15 @@ const parseEmbedData = (config: IEmbedConfig, rssData?: IRss): IEmbedData => {
   const followUrls = {
     ...((subscribeUrl || feedUrl) && { rss: subscribeUrl || feedUrl })
   };
+  const shareUrl = showPlaylist ? rssShareUrl : audio.link || rssShareUrl;
 
   const data: IEmbedData = {
     ...(bgImageUrl && { bgImageUrl }),
     ...(audioHasProps && { audio }),
     ...(playlist && playlist.length > 1 && { playlist }),
-    ...(feedUrl && {
-      rssTitle,
-      shareUrl: showPlaylist ? rssShareUrl : audio.link,
-      ...(rssItunesOwner && { owner: rssItunesOwner })
-    }),
+    ...(rssTitle && { rssTitle }),
+    ...(shareUrl && { shareUrl }),
+    ...(rssItunesOwner && { owner: rssItunesOwner }),
     followUrls,
     ...(paymentPointer && { paymentPointer })
   };


### PR DESCRIPTION
Closes #86 

- rss proxy errors return 400 response
- show error message for bad feed URL's
- add same error handling and messaging to listen page

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:4300/e?uf=https://google.com.

> ...then...

- [ ] Ensure error message is shown.
- [ ] Ensure document responds with a 400 status code.
- [ ] Ensure the same occurs for RSS landing pages: http://localhost:4300/listen?uf=https://google.com
