### PR TITLE
91: ensure audio url has protocol

### DIFF
--- a/lib/generate/string/generateAudioUrl.spec.ts
+++ b/lib/generate/string/generateAudioUrl.spec.ts
@@ -15,5 +15,11 @@ describe('lib/generate/string', () => {
 
       expect(result).toMatch('http://foo.com/bar.mp3?_from=AcmePlayer');
     });
+
+    test('should add `https` protocol when one is not present.', () => {
+      const result = generateAudioUrl('//foo.com/bar.mp3');
+
+      expect(result).toMatch('https://foo.com/bar.mp3?_from=play.prx.org');
+    });
   });
 });

--- a/lib/generate/string/generateAudioUrl.ts
+++ b/lib/generate/string/generateAudioUrl.ts
@@ -6,7 +6,10 @@
  */
 
 const generateAudioUrl = (audioUrl: string) => {
-  const url = new URL(audioUrl);
+  const audioUrlWithProtocol = /^\/\//.test(audioUrl)
+    ? `https:${audioUrl}`
+    : audioUrl;
+  const url = new URL(audioUrlWithProtocol);
 
   if (!url.searchParams.get('_from')) {
     url.searchParams.set('_from', 'play.prx.org');


### PR DESCRIPTION
Closes #91 

- When parsing RSS enclosure URL's, ensure it gets a protocol.

## To Review

- [ ] Code review.
- [ ] Run `yarn test`.
