### PR TITLE
Adds 'Download' button onto embed player share menu

### DIFF
--- a/assets/svg/icons/FileDownload.svg
+++ b/assets/svg/icons/FileDownload.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" viewBox="0 0 24 24" ><g><rect fill="none"/></g><g><path d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"/></g></svg>

--- a/components/Player/FileDownloadButton/FileDownloadButton.tsx
+++ b/components/Player/FileDownloadButton/FileDownloadButton.tsx
@@ -1,0 +1,35 @@
+/**
+ * @file FileDownloadButton.tsx
+ * Downlown MP3 Button for embed player and browser pages
+ */
+
+import type React from 'react';
+import { useContext } from 'react';
+import PlayerContext from '@contexts/PlayerContext';
+import FileDownload from '@svg/icons/FileDownload.svg';
+import MenuButton from '@components/MenuButton';
+
+export interface IFileDownloadButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const FileDownloadButton: React.FC<IFileDownloadButtonProps> = ({
+  className
+}) => {
+  const { state } = useContext(PlayerContext);
+  const { currentTrackIndex, tracks } = state;
+  const { url } = tracks[currentTrackIndex];
+
+  return (
+    <MenuButton
+      className={className}
+      action="link"
+      label="Download Audio"
+      type="button"
+      linkHref={url}
+    >
+      <FileDownload />
+    </MenuButton>
+  );
+};
+
+export default FileDownloadButton;

--- a/components/Player/FileDownloadButton/index.ts
+++ b/components/Player/FileDownloadButton/index.ts
@@ -1,0 +1,3 @@
+import FileDownloadButton from './FileDownloadButton';
+
+export default FileDownloadButton;

--- a/components/Player/PlayerShareMenu/PlayerShareMenu.tsx
+++ b/components/Player/PlayerShareMenu/PlayerShareMenu.tsx
@@ -15,6 +15,7 @@ import PlayerShareTwitterButton from '../PlayerShareTwitterButton';
 import PlayerShareEmailButton from '../PlayerShareEmailButton';
 import CopyLinkButton from '../CopyLinkButton';
 import styles from './PlayerShareMenu.module.scss';
+import FileDownloadButton from '../FileDownloadButton';
 
 export interface IPlayerShareMenuProps extends IModalProps {
   onOpen(): void;
@@ -53,6 +54,8 @@ const PlayerShareMenu: React.FC<IPlayerShareMenuProps> = ({
           <PlayerShareEmailButton />
 
           <CopyLinkButton />
+
+          <FileDownloadButton />
 
           {embedHtml && (
             <MenuButton


### PR DESCRIPTION
Closes #93 

- Adds a `download mp3 file` button onto embed player in pop-out modal's share menu.

Note that PRX audio will trigger a direct download, third party audio will open a new media player tab where the file can be saved.

## To Review
- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to [localhost:4300](http://localhost:4300/embed?uf=http://feed.songexploder.net/SongExploder&sp=10).