### PR TITLE
104: Serial feed sorting

### DIFF
--- a/interfaces/data/IRssItem.ts
+++ b/interfaces/data/IRssItem.ts
@@ -4,6 +4,7 @@
 
 import type Parser from 'rss-parser';
 import { IRssPodcastValue } from './IRssPodcast';
+
 export interface IRssItem extends Parser.Item {
   [key: string]: any;
   itunes?: {

--- a/lib/fetch/rss/fetchRssFeed.ts
+++ b/lib/fetch/rss/fetchRssFeed.ts
@@ -3,12 +3,16 @@ import type { IRss } from '@interfaces/data';
 import { decoratePodcast } from './decoratePodcast';
 
 type CustomFeed = { 'podcast:value': any; 'itunes:type': string };
-type CustomItem = { 'podcast:value': any };
+type CustomItem = {
+  'podcast:value': any;
+  itunes: any;
+  'itunes:episodeType': string;
+};
 
 const parser: Parser<CustomFeed, CustomItem> = new Parser({
   customFields: {
     feed: ['podcast:value', 'itunes:type'],
-    item: ['podcast:value']
+    item: ['podcast:value', 'itunes:episodeType']
   }
 });
 
@@ -38,7 +42,14 @@ const fetchRssFeed = async (feedUrl: string): Promise<IRss> => {
         itunes: {
           ...feed.itunes,
           type: feed['itunes:type']
-        }
+        },
+        items: feed.items.map((item) => ({
+          ...item,
+          itunes: {
+            ...item.itunes,
+            episodeType: item['itunes:episodeType']
+          }
+        }))
       })
     };
 

--- a/lib/parse/data/parseRssItems.spec.ts
+++ b/lib/parse/data/parseRssItems.spec.ts
@@ -235,5 +235,59 @@ describe('lib/parse/data', () => {
       expect(result.length).toBe(1);
       expect(result[0].guid).toBe('foo-1');
     });
+
+    test('should return items sorted by season then episode in ascending order', () => {
+      const config: IEmbedConfig = { showPlaylist: 'all' };
+      const result = parseRssItems(
+        {
+          ...mockRssData,
+          itunes: {
+            type: 'serial'
+          },
+          items: [
+            {
+              guid: 'GUID:2:1',
+              itunes: {
+                season: '2',
+                episode: '1'
+              }
+            },
+            {
+              guid: 'GUID:1:2',
+              itunes: {
+                season: '1',
+                episode: '2'
+              }
+            },
+            {
+              guid: 'GUID:1:1',
+              itunes: {
+                episode: '1'
+              }
+            },
+            {
+              guid: 'GUID:2:2',
+              itunes: {
+                season: '2',
+                episode: '2'
+              }
+            },
+            {
+              guid: 'GUID:1:3',
+              itunes: {
+                episode: '3'
+              }
+            }
+          ]
+        },
+        config
+      );
+
+      expect(result[0].guid).toBe('GUID:1:1');
+      expect(result[1].guid).toBe('GUID:1:2');
+      expect(result[2].guid).toBe('GUID:1:3');
+      expect(result[3].guid).toBe('GUID:2:1');
+      expect(result[4].guid).toBe('GUID:2:2');
+    });
   });
 });

--- a/lib/parse/data/parseRssItems.ts
+++ b/lib/parse/data/parseRssItems.ts
@@ -17,7 +17,7 @@ const parseRssItems = (
 
   const { link, image, itunes } = rssData;
   const { url: rssImageUrl } = image || {};
-  const { image: rssItunesImage } = itunes || {};
+  const { image: rssItunesImage, type: rssItunesType } = itunes || {};
   const imageUrl = rssItunesImage || rssImageUrl;
   const { episodeGuid, showPlaylist, playlistCategory, playlistSeason } =
     config;
@@ -84,6 +84,20 @@ const parseRssItems = (
           // episode was filtered out. Prepend it to items.
           return [episode, ...items];
         },
+        // Sort Serial feed items.
+        (items: IRssItem[]) =>
+          rssItunesType === 'serial'
+            ? [...items].sort((a, b) => {
+                const { season: aSeason = '1', episode: aEpisode } = a.itunes;
+                const { season: bSeason = '1', episode: bEpisode } = b.itunes;
+
+                if (aSeason === bSeason) {
+                  return parseInt(aEpisode, 10) - parseInt(bEpisode, 10);
+                }
+
+                return parseInt(aSeason, 10) - parseInt(bSeason, 10);
+              })
+            : items,
         // Cap number of items to configured length.
         (items: IRssItem[]) =>
           showPlaylist === 'all' ? items : items.slice(0, showPlaylist)

--- a/lib/parse/data/parseRssItems.ts
+++ b/lib/parse/data/parseRssItems.ts
@@ -88,10 +88,20 @@ const parseRssItems = (
         (items: IRssItem[]) =>
           rssItunesType === 'serial'
             ? [...items].sort((a, b) => {
-                const { season: aSeason = '1', episode: aEpisode } = a.itunes;
-                const { season: bSeason = '1', episode: bEpisode } = b.itunes;
+                const {
+                  season: aSeason = '1',
+                  episode: aEpisode,
+                  episodeType: aEpisodeType
+                } = a.itunes;
+                const {
+                  season: bSeason = '1',
+                  episode: bEpisode,
+                  episodeType: bEpisodeType
+                } = b.itunes;
 
                 if (aSeason === bSeason) {
+                  if (aEpisodeType === 'trailer') return -1;
+                  if (bEpisodeType === 'trailer') return 1;
                   return parseInt(aEpisode, 10) - parseInt(bEpisode, 10);
                 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5639,7 +5639,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
 
 rss-parser@^3.12.0:
   version "3.12.0"
-  resolved "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz"
+  resolved "https://registry.yarnpkg.com/rss-parser/-/rss-parser-3.12.0.tgz#b8888699ea46304a74363fbd8144671b2997984c"
   integrity sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==
   dependencies:
     entities "^2.0.3"


### PR DESCRIPTION
Co-authored-by: Alexa M. <a-maci29@users.noreply.github.com>

Closes #104 

- adds step for RSS item parser to check if a feed has `itunes:type` set to serial, then sort items by season and episode in ascending order.

## To Review

- [x] Checkout Branch.
- [x] Run `asdf install`.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to http://localhost:4300/e?uf=https://afrofuturism.podcast.carnegiehall.org/&sp=all.

> ...then...

- [x] Ensure episodes are listed in serial ordering (oldest to newest based on season and episode)
- [x] run `yarn test` and ensure all tests pass
