### PR TITLE
107: Add accent color param parser

### DIFF
--- a/lib/parse/config/parseAccentColorParam.spec.ts
+++ b/lib/parse/config/parseAccentColorParam.spec.ts
@@ -1,0 +1,36 @@
+import parseAccentColorParam from './parseAccentColorParam';
+
+describe('lib/parse/config', () => {
+  describe('parseAccentColorParam', () => {
+    test('should convert single value to array', () => {
+      const result = parseAccentColorParam('ff0000');
+
+      expect(result).toBeInstanceOf(Array);
+    });
+
+    test('should prefix colors with `#`', () => {
+      const result = parseAccentColorParam('ff0000');
+
+      expect(result[0]).toBe('#ff0000');
+    });
+
+    test('should allow valid CSS hex colors, with optional gradient position percentage', () => {
+      const result = parseAccentColorParam(['ff0000', '7ab3f8e9 80%', '00f']);
+
+      expect(result.length).toBe(3);
+      expect(result).toStrictEqual(['#ff0000', '#7ab3f8e9 80%', '#00f']);
+    });
+
+    test('should filter out bad color input', () => {
+      const result = parseAccentColorParam(['INVALID_COLOR', 'ff0000']);
+
+      expect(result).toStrictEqual(['#ff0000']);
+    });
+
+    test('should return null when all input is invalid', () => {
+      const result = parseAccentColorParam('INVALID_COLOR');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/lib/parse/config/parseAccentColorParam.ts
+++ b/lib/parse/config/parseAccentColorParam.ts
@@ -1,0 +1,20 @@
+/**
+ *
+ * @param param Querystring param value.
+ * @returns Array of HEX CSS color strings. Can contain syntax for color location in gradient colors.
+ */
+const parseAccentColorParam = (param: string | string[]): string[] => {
+  const colors = (Array.isArray(param) ? param : [param])
+    .map((ac) =>
+      /^(?:[a-f0-9]{2}[a-f0-9]{2}[a-f0-9]{2}(?:[a-f0-9]{2})?|[a-f0-9]{3})(?:\s1?\d?\d%)?$/i.test(
+        ac
+      )
+        ? `#${ac}`
+        : null
+    )
+    .filter((ac) => !!ac);
+
+  return colors.length ? colors : null;
+};
+
+export default parseAccentColorParam;

--- a/lib/parse/config/parseEmbedParamsToConfig.ts
+++ b/lib/parse/config/parseEmbedParamsToConfig.ts
@@ -2,6 +2,7 @@ import type { IEmbedConfig, IEmbedParams } from '@interfaces/config';
 import { EmbedParamKeysMap } from '@interfaces/config';
 import convertStringToBoolean from '@lib/convert/string/convertStringToBoolean';
 import convertStringToInteger from '@lib/convert/string/convertStringToInteger';
+import parseAccentColorParam from './parseAccentColorParam';
 
 /**
  * Parse query parameters into player config object.
@@ -39,15 +40,7 @@ const parseEmbedParamsToConfig = (params: IEmbedParams): IEmbedConfig => {
         case 'accentColor':
           return {
             ...a,
-            [prop]: (Array.isArray(v) ? (v as string[]) : [v])
-              .map((ac) =>
-                /^[a-f0-9]{2}[a-f0-9]{2}[a-f0-9]{2}(?:[a-f0-9]{2})?(?:\s1?\d?\d%)?$/i.test(
-                  ac
-                )
-                  ? `#${ac}`
-                  : null
-              )
-              .filter((ac) => !!ac)
+            [prop]: parseAccentColorParam(v)
           };
 
         default:

--- a/lib/parse/config/parseListenParamsToConfig.ts
+++ b/lib/parse/config/parseListenParamsToConfig.ts
@@ -1,6 +1,7 @@
 import type { IListenConfig, IListenParams } from '@interfaces/config';
 import { EmbedParamKeysMap } from '@interfaces/config';
 import convertStringToInteger from '@lib/convert/string/convertStringToInteger';
+import parseAccentColorParam from './parseAccentColorParam';
 
 /**
  * Parse query parameters into listen config object.
@@ -32,15 +33,7 @@ const parseListenParamsToConfig = (params: IListenParams): IListenConfig => {
         case 'accentColor':
           return {
             ...a,
-            [prop]: (Array.isArray(v) ? (v as string[]) : [v])
-              .map((ac) =>
-                /^[a-f0-9]{2}[a-f0-9]{2}[a-f0-9]{2}(?:[a-f0-9]{2})?(?:\s1?\d?\d%)?$/i.test(
-                  ac
-                )
-                  ? `#${ac}`
-                  : null
-              )
-              .filter((ac) => !!ac)
+            [prop]: parseAccentColorParam(v)
           };
 
         default:


### PR DESCRIPTION
Closes #107 

- bad accent color input should not cause 5XX errors
- add support for 3 char HEX colors

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.

> ...then...

- [ ] Go to http://localhost:4300/e?uf=https://corinnaandtheking.projectbrazen.com/&ac=000.
- [ ] Ensure progress bar is black.
- [ ] Go to http://localhost:4300/e?uf=https://corinnaandtheking.projectbrazen.com/&ac=NOTACOLOR
- [ ] Ensure player renders without error.
- [ ] Run `yarn test --coverage -o`.
- [ ] Ensure all tests pass and coverage is 💯 .
