### PR TITLE
113: Parse multiple podcast value

### DIFF
--- a/components/PrxImage/PrxImage.tsx
+++ b/components/PrxImage/PrxImage.tsx
@@ -39,6 +39,7 @@ const PrxImage = forwardRef<{ complete: boolean }, IPrxImageProps>(
       layout,
       lazyRoot,
       objectFit,
+      onLoad,
       onLoadingComplete
     };
 
@@ -59,7 +60,6 @@ const PrxImage = forwardRef<{ complete: boolean }, IPrxImageProps>(
             src={src as string}
             alt={alt}
             style={{ objectFit }}
-            onLoad={onLoad}
             {...other}
             className={imageClassNames}
           />
@@ -71,6 +71,7 @@ const PrxImage = forwardRef<{ complete: boolean }, IPrxImageProps>(
           src={src as string}
           alt={alt}
           className={className}
+          onLoad={onLoad}
           {...other}
         />
       )

--- a/lib/fetch/rss/decoratePodcast.ts
+++ b/lib/fetch/rss/decoratePodcast.ts
@@ -5,14 +5,20 @@ import {
 import type { IRss, IRssItem } from '@interfaces/data';
 
 export const extractPodcastValue = (data): IRssPodcastValue => {
-  const recipients: IRssPodcastValueRecipient[] = data['podcast:value']?.[
+  const podcastValueWmIlp = (data['podcast:value'] as any[])?.find(
+    ({ $: { type, method } }) => type === 'webmonetization' && method === 'ILP'
+  );
+
+  if (!podcastValueWmIlp) return undefined;
+
+  const recipients: IRssPodcastValueRecipient[] = podcastValueWmIlp[
     'podcast:valueRecipient'
-  ].map((recipient) => ({
+  ]?.map((recipient) => ({
     ...recipient.$
   }));
 
-  const podcastValue: IRssPodcastValue = data['podcast:value'] && {
-    ...data['podcast:value'].$,
+  const podcastValue: IRssPodcastValue = {
+    ...podcastValueWmIlp.$,
     ...(recipients?.length > 0 && { valueRecipients: recipients })
   };
 

--- a/lib/fetch/rss/fetchRssFeed.ts
+++ b/lib/fetch/rss/fetchRssFeed.ts
@@ -40,8 +40,6 @@ const fetchRssFeed = async (feedUrl: string): Promise<IRss> => {
   try {
     const feed = await parser.parseURL(feedUrl);
 
-    console.log(feed['podcast:value']);
-
     const result = {
       ...decoratePodcast(feed),
       ...(feed['itunes:type'] && {

--- a/lib/fetch/rss/fetchRssFeed.ts
+++ b/lib/fetch/rss/fetchRssFeed.ts
@@ -11,7 +11,11 @@ type CustomItem = {
 
 const parser: Parser<CustomFeed, CustomItem> = new Parser({
   customFields: {
-    feed: ['podcast:value', 'itunes:type'],
+    feed: [
+      // @ts-ignore
+      ['podcast:value', 'podcast:value', { keepArray: true }],
+      'itunes:type'
+    ],
     item: ['podcast:value', 'itunes:episodeType']
   }
 });
@@ -35,6 +39,8 @@ class RssProxyError extends Error {
 const fetchRssFeed = async (feedUrl: string): Promise<IRss> => {
   try {
     const feed = await parser.parseURL(feedUrl);
+
+    console.log(feed['podcast:value']);
 
     const result = {
       ...decoratePodcast(feed),


### PR DESCRIPTION
Closes #113

- Filter `podcast:value` items to first item with `type = 'webmonetization'` and `method = 'ILP'`, then use that in parsed feed data.
- fixes a bug where images from a a third party server would not un-blur when loaded.

## To Review

- [ ] Use the preview deployment: LINK_HERE

> ...or...

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:4300/api/proxy/rss?u=https://podnews.net/rss.

> ...then...

- [ ] Ensure `podcast` prop is in root object and contains the data for the correct `podcast:value` node.
- [ ] Go to http://localhost:4300/e?uf=https://podnews.net/rss
- [ ] Ensure web monetization icon is shown next to progress bar.
- [ ] Ensure thumbnail doesn't remain blurred after it loads.
- [ ] Run `yarn test` and completes without error.
