### PR TITLE
HOTFIX: Improve play/pause in episode view

### DIFF
--- a/components/Listen/Listen.tsx
+++ b/components/Listen/Listen.tsx
@@ -227,6 +227,11 @@ const Listen = ({ config, data }: IListenPageProps) => {
     ]
   );
 
+  const renderPlaylist = useMemo(
+    () => <EpisodeList onEpisodeClick={handleEpisodeClick} />,
+    [handleEpisodeClick]
+  );
+
   useEffect(() => {
     if (view === 'episode' && !episode) {
       dispatch({
@@ -287,7 +292,7 @@ const Listen = ({ config, data }: IListenPageProps) => {
               )}
             </div>
             <div className={styles.podcastEpisodes}>
-              <EpisodeList onEpisodeClick={handleEpisodeClick} />
+              {view.indexOf('podcast') !== -1 && renderPlaylist}
             </div>
           </div>
 

--- a/components/Listen/Listen.tsx
+++ b/components/Listen/Listen.tsx
@@ -13,7 +13,6 @@ import {
   useRef,
   useState
 } from 'react';
-import Head from 'next/head';
 import { useRouter } from 'next/router';
 import clsx from 'clsx';
 import PlayerContext from '@contexts/PlayerContext';
@@ -227,11 +226,6 @@ const Listen = ({ config, data }: IListenPageProps) => {
     ]
   );
 
-  const renderPlaylist = useMemo(
-    () => <EpisodeList onEpisodeClick={handleEpisodeClick} />,
-    [handleEpisodeClick]
-  );
-
   useEffect(() => {
     if (view === 'episode' && !episode) {
       dispatch({
@@ -242,9 +236,7 @@ const Listen = ({ config, data }: IListenPageProps) => {
 
   return (
     <>
-      <Head>
-        <style>{`:root {${rootStyles}} body { overflow: hidden; }`}</style>
-      </Head>
+      <style>{`:root {${rootStyles}} body { overflow: hidden; }`}</style>
       <ThemeVars theme="Listen" cssProps={styles} />
       <div className={styles.root} data-view={view} data-theme={theme}>
         <div className={styles.background}>
@@ -292,7 +284,9 @@ const Listen = ({ config, data }: IListenPageProps) => {
               )}
             </div>
             <div className={styles.podcastEpisodes}>
-              {view.indexOf('podcast') !== -1 && renderPlaylist}
+              {view.indexOf('podcast') !== -1 && (
+                <EpisodeList onEpisodeClick={handleEpisodeClick} />
+              )}
             </div>
           </div>
 

--- a/components/ThemeVars/ThemeVars.tsx
+++ b/components/ThemeVars/ThemeVars.tsx
@@ -4,7 +4,6 @@
  */
 
 import type React from 'react';
-import Head from 'next/head';
 
 export interface IThemeVarsProps {
   theme: string;
@@ -24,11 +23,9 @@ const ThemeVars: React.FC<IThemeVarsProps> = ({
 
   return (
     hasCssVars && (
-      <Head>
-        <style key={`ThemeVars:${key}`}>{`:root {\n  ${cssVars.join(
-          '\n  '
-        )}\n}`}</style>
-      </Head>
+      <style key={`ThemeVars:${key}`}>{`:root {\n  ${cssVars.join(
+        '\n  '
+      )}\n}`}</style>
     )
   );
 };


### PR DESCRIPTION
- memo render of playlist element
- don't render playlist element in episode view

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:4300/listen?uf=https%3A%2F%2Flatinousa.feeds.futuromedia.org%2F&ge=prx_344_9c0a0d23-5974-4dd3-9a35-a50ba6f0f151.

> ...then...

- [ ] Play audio and ensure it plays without significant delay.
- [ ] Got to playlist view by clicking arrow in episode header.
- [ ] Expect a delay rendering the playlist.
- [ ] Expect play/pause in playlist view to be slow.
- [ ] Click on another episode title to view it.
- [ ] Expect view transition to be quicker.
- [ ] Expect play/pause to be significantly quicker.
- [ ] Go back to playlist view.
- [ ] Expect view transition to be slow, but better than first transition.
