### PR TITLE
HOTFIX: Progress bar should not collapse in a flex parent

### DIFF
--- a/components/Player/PlayerProgress/PlayerProgress.module.scss
+++ b/components/Player/PlayerProgress/PlayerProgress.module.scss
@@ -12,6 +12,7 @@ $playerProgress-gap: 20px;
 }
 
 .root {
+  flex-grow: 1;
   display: grid;
   grid-template-columns: min-content 1fr min-content;
   gap: $playerProgress-gap;


### PR DESCRIPTION
- Fix progress bar being displayed with 0px width

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:4300/e?uf=http%3A%2F%2Ffeed.songexploder.net%2FSongExploder&ge=prx_93_2c6d2180-ec4e-47dd-9d75-3535ea797da0.

> ...then...

- [ ] Expect progress bar to be visible.
