### PR TITLE
Embed config audio preview url

### DIFF
--- a/components/Embed/Embed.tsx
+++ b/components/Embed/Embed.tsx
@@ -56,7 +56,7 @@ export interface IEmbedLayoutBreakPoint {
 }
 
 const Embed = ({ config, data }: IEmbedProps) => {
-  const { showCoverArt, showPlaylist, accentColor, theme, isPrivate } = config;
+  const { showCoverArt, showPlaylist, accentColor, theme } = config;
   const {
     audio,
     playlist,
@@ -377,7 +377,6 @@ const Embed = ({ config, data }: IEmbedProps) => {
                         embedHtml={embedHtml}
                         isOpen={shareShown}
                         portalId="embed-modals"
-                        isPrivate={isPrivate}
                       />
 
                       <SupportMenu

--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -48,7 +48,8 @@ const Player: React.FC<IPlayerProps> = ({
     [currentTrack.duration]
   );
   const isLastTrack = currentTrackIndex === tracks.length - 1;
-  const { url } = currentTrack;
+  const { url, previewUrl } = currentTrack;
+  const currentTrackUrl = previewUrl || url;
 
   const boundedTime = useCallback(
     (time: number) =>
@@ -437,9 +438,9 @@ const Player: React.FC<IPlayerProps> = ({
   }, [currentTime]);
 
   useEffect(() => {
-    loadAudio(url);
+    loadAudio(currentTrackUrl);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [url]);
+  }, [currentTrackUrl]);
 
   useEffect(
     () => () => {

--- a/components/Player/PlayerShareMenu/PlayerShareMenu.tsx
+++ b/components/Player/PlayerShareMenu/PlayerShareMenu.tsx
@@ -21,7 +21,6 @@ export interface IPlayerShareMenuProps extends IModalProps {
   onOpen(): void;
   className?: string;
   embedHtml?: string;
-  isPrivate?: boolean;
 }
 
 const PlayerShareMenu: React.FC<IPlayerShareMenuProps> = ({
@@ -30,7 +29,6 @@ const PlayerShareMenu: React.FC<IPlayerShareMenuProps> = ({
   isOpen,
   portalId,
   embedHtml,
-  isPrivate,
   className
 }) => {
   const handleClick = () => {
@@ -57,20 +55,16 @@ const PlayerShareMenu: React.FC<IPlayerShareMenuProps> = ({
 
           <CopyLinkButton />
 
-          {!isPrivate && (
-            <>
-              <FileDownloadButton />
+          <FileDownloadButton />
 
-              {embedHtml && (
-                <MenuButton
-                  action="clipboard"
-                  clipboardText={embedHtml}
-                  label="Embed Code"
-                >
-                  <CodeIcon />
-                </MenuButton>
-              )}
-            </>
+          {embedHtml && (
+            <MenuButton
+              action="clipboard"
+              clipboardText={embedHtml}
+              label="Embed Code"
+            >
+              <CodeIcon />
+            </MenuButton>
           )}
         </nav>
       </Modal>

--- a/interfaces/config/IEmbedConfig.ts
+++ b/interfaces/config/IEmbedConfig.ts
@@ -150,7 +150,6 @@ export interface IEmbedConfig {
   showCoverArt?: boolean;
   accentColor?: string[];
   theme?: 'light' | 'dark' | 'auto';
-  isPrivate?: boolean;
   maxWidth?: number;
 }
 

--- a/interfaces/config/IEmbedConfig.ts
+++ b/interfaces/config/IEmbedConfig.ts
@@ -28,6 +28,14 @@ export interface IEmbedParams extends ParsedUrlQuery {
   ua?: string | string[];
 
   /**
+   * Use to provide a preview safe audio URL.
+   *
+   * Do NOT include when generating share URL's.
+   * (eg. clipboard copied URL, embed iframe URL params).
+   */
+  uap?: string | string[];
+
+  /**
    * Use to override URL of image initial shown as player background.
    */
   ui?: string | string[];
@@ -126,6 +134,7 @@ export interface IEmbedConfig {
   subtitle?: string;
   ctaTitle?: string;
   audioUrl?: string;
+  audioUrlPreview?: string;
   imageUrl?: string;
   episodeImageUrl?: string;
   feedUrl?: string;
@@ -154,6 +163,7 @@ EmbedParamKeysMap.set('tt', 'title');
 EmbedParamKeysMap.set('ts', 'subtitle');
 EmbedParamKeysMap.set('tc', 'ctaTitle');
 EmbedParamKeysMap.set('ua', 'audioUrl');
+EmbedParamKeysMap.set('uap', 'audioUrlPreview');
 EmbedParamKeysMap.set('ui', 'imageUrl');
 EmbedParamKeysMap.set('ue', 'episodeImageUrl');
 EmbedParamKeysMap.set('uf', 'feedUrl');
@@ -172,6 +182,10 @@ EmbedParamKeysMap.set('th', 'theme');
 
 /**
  * Map of embed config property keys to embed parameter keys.
+ *
+ * Leave out any config key that should not persist when generating share
+ * URL's.
+ * (eg. clipboard copied URL, embed iframe URL params).
  */
 export const EmbedConfigKeysMap: Map<keyof IEmbedConfig, keyof IEmbedParams> =
   new Map();

--- a/interfaces/data/IAudioData.ts
+++ b/interfaces/data/IAudioData.ts
@@ -26,7 +26,7 @@ export interface IAudioData {
    * Should be used for playback when provided.
    * Do NOT include this in shared URL's or HTML markup.
    */
-  previewUrl: string;
+  previewUrl?: string;
 
   /**
    * Title to be displayed in player.

--- a/interfaces/data/IAudioData.ts
+++ b/interfaces/data/IAudioData.ts
@@ -22,6 +22,13 @@ export interface IAudioData {
   url: string;
 
   /**
+   * Source URL for the preview audio file.
+   * Should be used for playback when provided.
+   * Do NOT include this in shared URL's or HTML markup.
+   */
+  previewUrl: string;
+
+  /**
    * Title to be displayed in player.
    */
   title: string;

--- a/lib/parse/data/parseEmbedData.spec.ts
+++ b/lib/parse/data/parseEmbedData.spec.ts
@@ -80,6 +80,7 @@ describe('lib/parse/data', () => {
         title: 'Foo',
         subtitle: 'Foo to the bar',
         audioUrl: 'http://foo.com/foo.mp3',
+        audioUrlPreview: 'http://preview.foo.com/foo.mp3',
         imageUrl: 'http://foo.com/bg.png',
         episodeImageUrl: 'http://foo.com/foo.png',
         subscribeUrl: 'http://foo.com/feed.rss'
@@ -90,6 +91,7 @@ describe('lib/parse/data', () => {
         title: 'Foo',
         subtitle: 'Foo to the bar',
         url: 'http://foo.com/foo.mp3?_from=play.prx.org',
+        previewUrl: 'http://preview.foo.com/foo.mp3?_from=play.prx.org',
         imageUrl: 'http://foo.com/foo.png'
       });
       expect(result.followUrls.rss).toBe('http://foo.com/feed.rss');

--- a/lib/parse/data/parseEmbedData.ts
+++ b/lib/parse/data/parseEmbedData.ts
@@ -17,6 +17,7 @@ const parseEmbedData = (config: IEmbedConfig, rssData?: IRss): IEmbedData => {
     title: configTitle,
     subtitle: configSubtitle,
     audioUrl: configAudioUrl,
+    audioUrlPreview: configAudioUrlPreview,
     episodeGuid: configEpisodeGuid,
     episodeImageUrl: configImageUrl,
     showPlaylist
@@ -69,6 +70,9 @@ const parseEmbedData = (config: IEmbedConfig, rssData?: IRss): IEmbedData => {
     ...(configTitle && { title: configTitle }),
     ...(configSubtitle && { subtitle: configSubtitle }),
     ...(configAudioUrl && { url: generateAudioUrl(configAudioUrl) }),
+    ...(configAudioUrlPreview && {
+      previewUrl: generateAudioUrl(configAudioUrlPreview)
+    }),
     ...(configImageUrl && { imageUrl: configImageUrl })
   };
   const audioHasProps = Object.keys(audio).length > 0 && !!audio.url;


### PR DESCRIPTION
- Adds support for a `uap` parameter that will be used for playback.
- Removes `isPrivate` prop from embed config and related logic. No longer required.

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.

> ...then...

- [ ] While reviewing PRX/feeder.prx.org#823, have this server running.
- [ ] Ensure your feeder .env includes `PLAY_HOST=play.prx.test`.
- [ ] Edit an unpublished episode.
- [ ] Ensure Embed Player Link and Iframe values do not include the `_t` param with audio URL's params.
- [ ] Ensure Audio Link and Embed Code copied from Iframe do not include the `_t` param with audio URL's params.
