### PR TITLE
HOTFIX: 500 on `/listen` page when filter options result in no playlist items

### DIFF
--- a/lib/parse/data/parseRssItems.spec.ts
+++ b/lib/parse/data/parseRssItems.spec.ts
@@ -236,6 +236,19 @@ describe('lib/parse/data', () => {
       expect(result[0].guid).toBe('foo-1');
     });
 
+    test('should return undefined when rss has no items', () => {
+      const config: IEmbedConfig = { showPlaylist: 'all', playlistSeason: 999 };
+      const result = parseRssItems(
+        {
+          ...mockRssData,
+          items: []
+        },
+        config
+      );
+
+      expect(result).toBeUndefined();
+    });
+
     test('should return items sorted by season then episode in ascending order', () => {
       const config: IEmbedConfig = { showPlaylist: 'all' };
       const result = parseRssItems(

--- a/lib/parse/data/parseRssItems.ts
+++ b/lib/parse/data/parseRssItems.ts
@@ -13,7 +13,7 @@ const parseRssItems = (
   config: IEmbedConfig,
   itemParser?: Function
 ) => {
-  if (!rssData || !rssData.items) return undefined;
+  if (!rssData || !rssData.items?.length) return undefined;
 
   const { link, image, itunes } = rssData;
   const { url: rssImageUrl } = image || {};
@@ -42,6 +42,7 @@ const parseRssItems = (
         })
       } as IRssItem)
   );
+
   const episode =
     episodeGuid && rssItems.find((item) => item.guid === episodeGuid);
   let resultItems: IRssItem[];

--- a/lib/parse/data/parseRssItems.ts
+++ b/lib/parse/data/parseRssItems.ts
@@ -123,11 +123,11 @@ const parseRssItems = (
 
   // If we have no items at this point, just use the first one.
   if (!resultItems?.length) {
-    resultItems = [rssItems[0]];
+    resultItems = rssItems[0] && [rssItems[0]];
   }
 
-  // Return resulting items as audio data.
-  return resultItems.map(
+  // Return resulting items as audio data or `undefined`.
+  return resultItems?.map(
     (item) =>
       ({
         // Provide some default props inherited from feed.

--- a/pages/listen/index.tsx
+++ b/pages/listen/index.tsx
@@ -1,6 +1,6 @@
 /**
- * @file [episodeId].tsx
- * Landing page to listen to individual episode.
+ * @file listen/index.tsx
+ * Landing page for podcast using RSS data.
  */
 
 import type { GetServerSideProps } from 'next';
@@ -25,7 +25,7 @@ const ListenPage = ({ data, config, error }: IListenPageProps) => {
     episodes
   } = data;
   const episode =
-    episodeGuid && episodes.find(({ guid }) => guid === episodeGuid);
+    episodeGuid && episodes?.find(({ guid }) => guid === episodeGuid);
   const {
     title: episodeTitle,
     link: episodeLink,


### PR DESCRIPTION
- parser RSS items should no longe include `undefined` item in resulting array
- listen page should not attempt to find an episode if no episodes exist from rss parse
