### PR TITLE
128: Allow any prx subdomain to send post messages to preview page

### DIFF
--- a/pages/preview.tsx
+++ b/pages/preview.tsx
@@ -34,10 +34,7 @@ const PreviewPage = ({ config, rssData, error }: IPreviewPageProps) => {
   };
 
   function handlePostMessage(e: MessageEvent) {
-    if (
-      !/^https?:\/\/(feeder)(\.staging)?\.prx\.(org|tech|test)$/.test(e.origin)
-    )
-      return;
+    if (!/\.prx\.(org|tech|test)$/.test(e.origin)) return;
 
     setNewConfig((prevConfig) => ({
       ...prevConfig,


### PR DESCRIPTION
Closes #128 

- Broadens condition to allow origins ending with `.prx.org`, `.prx.tech`, or `.prx.test`
