### PR TITLE
HOTFIX: handle RSS items missing enclosure

### DIFF
--- a/lib/parse/data/parseRssItems.spec.ts
+++ b/lib/parse/data/parseRssItems.spec.ts
@@ -8,6 +8,7 @@ describe('lib/parse/data', () => {
       {
         guid: 'foo-1',
         categories: ['cat1', '  cat2', 'Cat3  '],
+        enclosure: { url: 'ENCLOSURE:URL' },
         itunes: {
           season: '1',
           categories: ['cat4'],
@@ -16,24 +17,28 @@ describe('lib/parse/data', () => {
       },
       {
         guid: 'foo-2',
-        categories: ['cat1', 'cat2']
+        categories: ['cat1', 'cat2'],
+        enclosure: { url: 'ENCLOSURE:URL' }
       },
       {
         guid: 'foo-3',
         categories: ['cat1', 'cat3'],
+        enclosure: { url: 'ENCLOSURE:URL' },
         itunes: {
           season: '1'
         }
       },
       {
         guid: 'foo-4',
+        enclosure: { url: 'ENCLOSURE:URL' },
         itunes: {
           season: '2',
           categories: ['cat2']
         }
       },
       {
-        guid: 'foo-5'
+        guid: 'foo-5',
+        enclosure: { url: 'ENCLOSURE:URL' }
       }
     ];
     const mockRssData: IRss = {
@@ -260,6 +265,7 @@ describe('lib/parse/data', () => {
           items: [
             {
               guid: 'GUID:2:1',
+              enclosure: { url: 'ENCLOSURE:URL' },
               itunes: {
                 season: '2',
                 episode: '1'
@@ -267,6 +273,7 @@ describe('lib/parse/data', () => {
             },
             {
               guid: 'GUID:1:2',
+              enclosure: { url: 'ENCLOSURE:URL' },
               itunes: {
                 season: '1',
                 episode: '2'
@@ -274,12 +281,14 @@ describe('lib/parse/data', () => {
             },
             {
               guid: 'GUID:1:1',
+              enclosure: { url: 'ENCLOSURE:URL' },
               itunes: {
                 episode: '1'
               }
             },
             {
               guid: 'GUID:2:2',
+              enclosure: { url: 'ENCLOSURE:URL' },
               itunes: {
                 season: '2',
                 episode: '2'
@@ -287,6 +296,7 @@ describe('lib/parse/data', () => {
             },
             {
               guid: 'GUID:1:3',
+              enclosure: { url: 'ENCLOSURE:URL' },
               itunes: {
                 episode: '3'
               }
@@ -301,6 +311,24 @@ describe('lib/parse/data', () => {
       expect(result[2].guid).toBe('GUID:1:3');
       expect(result[3].guid).toBe('GUID:2:1');
       expect(result[4].guid).toBe('GUID:2:2');
+    });
+
+    test('should filter out items w/o enclosure', () => {
+      const config: IEmbedConfig = { showPlaylist: 'all' };
+      const result = parseRssItems(
+        {
+          ...mockRssData,
+          items: [
+            ...mockRssData.items,
+            {
+              guid: 'GUID:NO_ENCLOSURE'
+            }
+          ]
+        },
+        config
+      );
+
+      expect(result[0].guid).not.toBe('GUID:NO_ENCLOSURE');
     });
   });
 });

--- a/lib/parse/data/parseRssItems.ts
+++ b/lib/parse/data/parseRssItems.ts
@@ -21,27 +21,29 @@ const parseRssItems = (
   const imageUrl = rssItunesImage || rssImageUrl;
   const { episodeGuid, showPlaylist, playlistCategory, playlistSeason } =
     config;
-  const rssItems = rssData.items.map(
-    (item) =>
-      ({
-        ...item,
-        ...((rssData.itunes?.categories ||
-          item.categories ||
-          item.itunes?.categories) && {
-          categories: [
-            ...(item.categories || []),
-            ...((item.itunes?.categories as string[]) || []),
-            // Inherit categories from channel when item is missing categories.
-            ...((!item.categories &&
-              !item.itunes?.categories &&
-              rssData.itunes.categories) ||
-              [])
-          ]
-            .map((c) => c.trim())
-            .reduce((a, c) => (a.indexOf(c) === -1 ? [...a, c] : a), [])
-        })
-      } as IRssItem)
-  );
+  const rssItems = rssData.items
+    .filter((item) => !!item.enclosure)
+    .map(
+      (item) =>
+        ({
+          ...item,
+          ...((rssData.itunes?.categories ||
+            item.categories ||
+            item.itunes?.categories) && {
+            categories: [
+              ...(item.categories || []),
+              ...((item.itunes?.categories as string[]) || []),
+              // Inherit categories from channel when item is missing categories.
+              ...((!item.categories &&
+                !item.itunes?.categories &&
+                rssData.itunes.categories) ||
+                [])
+            ]
+              .map((c) => c.trim())
+              .reduce((a, c) => (a.indexOf(c) === -1 ? [...a, c] : a), [])
+          })
+        } as IRssItem)
+    );
 
   const episode =
     episodeGuid && rssItems.find((item) => item.guid === episodeGuid);


### PR DESCRIPTION
- Update RSS item parser too filter out items missing enclosure data.

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:4300/preview?sp=10&uf=https%3A%2F%2Ff.prxu.org%2F5571%2Ffeed-rss.xml

> ...then...

- [ ] Ensure player renders w/o error. Should be missing latest episode title "Dominion’s Fox News Case Was Just the Beginning"
