### PR TITLE
HOTFIX: Embed RSS fetch via proxy API

### DIFF
--- a/lib/fetch/rss/RssProxyError.ts
+++ b/lib/fetch/rss/RssProxyError.ts
@@ -1,0 +1,12 @@
+class RssProxyError extends Error {
+  public url: string;
+
+  constructor(message: string, url: string) {
+    super(message);
+    this.name = 'RssProxyError';
+    this.message = message;
+    this.url = url;
+  }
+}
+
+export default RssProxyError;

--- a/lib/fetch/rss/fetchRssFeed.ts
+++ b/lib/fetch/rss/fetchRssFeed.ts
@@ -1,6 +1,7 @@
 import Parser from 'rss-parser';
 import type { IRss } from '@interfaces/data';
 import { decoratePodcast } from './decoratePodcast';
+import RssProxyError from './RssProxyError';
 
 type CustomFeed = { 'podcast:value': any; 'itunes:type': string };
 type CustomItem = {
@@ -19,17 +20,6 @@ const parser: Parser<CustomFeed, CustomItem> = new Parser({
     item: ['podcast:value', 'itunes:episodeType']
   }
 });
-
-class RssProxyError extends Error {
-  public url: string;
-
-  constructor(message: string, url: string) {
-    super(message);
-    this.name = 'RssProxyError';
-    this.message = message;
-    this.url = url;
-  }
-}
 
 /**
  * Fetch and parse RSS feed URL.

--- a/lib/fetch/rss/fetchRssProxy.ts
+++ b/lib/fetch/rss/fetchRssProxy.ts
@@ -1,4 +1,5 @@
 import { IRss } from '@interfaces/data';
+import RssProxyError from './RssProxyError';
 
 const fetchRssProxy = async (feedUrl: string) => {
   const apiProxyBaseUrl =
@@ -7,9 +8,14 @@ const fetchRssProxy = async (feedUrl: string) => {
 
   apiProxyUrl.searchParams.set('u', feedUrl);
 
-  const rssData = await fetch(apiProxyUrl.toString()).then((resp) =>
-    resp.ok ? resp.json() : null
-  );
+  const response = await fetch(apiProxyUrl.toString());
+
+  if (!response.ok) {
+    const { error } = await response.json();
+    throw new RssProxyError(error?.message, feedUrl);
+  }
+
+  const rssData = await response.json();
 
   return rssData as IRss;
 };

--- a/lib/fetch/rss/fetchRssProxy.ts
+++ b/lib/fetch/rss/fetchRssProxy.ts
@@ -1,0 +1,17 @@
+import { IRss } from '@interfaces/data';
+
+const fetchRssProxy = async (feedUrl: string) => {
+  const apiProxyBaseUrl =
+    process.env.API_BASE_URL || 'https://play.prx.org/api';
+  const apiProxyUrl = new URL(`${apiProxyBaseUrl}/proxy/rss`);
+
+  apiProxyUrl.searchParams.set('u', feedUrl);
+
+  const rssData = await fetch(apiProxyUrl.toString()).then((resp) =>
+    resp.ok ? resp.json() : null
+  );
+
+  return rssData as IRss;
+};
+
+export default fetchRssProxy;

--- a/pages/embed.tsx
+++ b/pages/embed.tsx
@@ -10,7 +10,7 @@ import type { IEmbedPageProps, IPageProps } from '@interfaces/page';
 import Head from 'next/head';
 import Error from 'next/error';
 import parseEmbedParamsToConfig from '@lib/parse/config/parseEmbedParamsToConfig';
-import fetchRssFeed from '@lib/fetch/rss/fetchRssFeed';
+import fetchRssProxy from '@lib/fetch/rss/fetchRssProxy';
 import parseEmbedData from '@lib/parse/data/parseEmbedData';
 import Embed from '@components/Embed/Embed';
 
@@ -40,13 +40,17 @@ export const getServerSideProps: GetServerSideProps<IPageProps> = async ({
   let rssData: IRss;
   let error: IPageError;
   try {
-    // ...try to fetch the feed...
-    rssData = config.feedUrl && (await fetchRssFeed(config.feedUrl));
+    // ...try to fetch the feed using RSS proxy API...
+    rssData = config.feedUrl && (await fetchRssProxy(config.feedUrl));
   } catch (e) {
     switch (e.name) {
       case 'RssProxyError':
         // ...and handle any RssProxyError as a 400.
         res.statusCode = 400;
+        res.setHeader(
+          'Cache-Control',
+          'no-cache, no-store, max-age=0, must-revalidate'
+        );
         error = {
           statusCode: 400,
           message: 'Bad Feed URL Provided'


### PR DESCRIPTION
- Updates embed route to fetch RSS data via the app's RSS proxy API endpoint
- Updates embed route to not cache 400 error responses

## To Review

- [x] Checkout Branch.
- [x] Add `API_BASE_URL="http://localhost:4300/api"` to your local `.env`
- [x] Run `asdf install`.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to http://localhost:4300/e?uf=http%3A%2F%2Ffeeds.prx.org%2FTOE&ge=prx_30_1f4f71f2-008e-4aca-ab96-03cc7e7f7e16

> ...then...

- [x] Ensure play loads.
- [x] Ensure you see requests to `/api/proxy/rss` in your terminal.
- [x] Go to http://localhost:4300/e?uf=http%3A%2F%2Ffeeds.prx.org%2F_SHOULD_NOT_EXIST_&ge=prx_30_1f4f71f2-008e-4aca-ab96-03cc7e7f7e16
- [x] Ensure you see "400 Bad Feed URL Provided" error.
- [x] Ensure cache-control headers are set to `no-cache`.
