### PR TITLE
142: Reduce logo size

### DIFF
--- a/components/Embed/Embed.tsx
+++ b/components/Embed/Embed.tsx
@@ -300,7 +300,14 @@ const Embed = ({ config, data }: IEmbedProps) => {
                   </div>
 
                   <div className={styles.logo}>
-                    {theme === 'light' ? <PrxLogoColor /> : <PrxLogo />}
+                    <a
+                      href="https://prx.org"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.logoLink}
+                    >
+                      {theme === 'light' ? <PrxLogoColor /> : <PrxLogo />}
+                    </a>
                   </div>
 
                   <div className={styles.menuToggle}>

--- a/styles/Embed.module.scss
+++ b/styles/Embed.module.scss
@@ -260,9 +260,10 @@ $player-thumbnail-size: 135px;
 .logo {
   grid-area: LOGO;
   align-self: start;
-
+}
+.logoLink {
   & > svg {
-    width: 80px;
+    width: 50px;
     display: inline-block;
     vertical-align: -webkit-baseline-middle;
     fill: var(--logo-color, currentColor);


### PR DESCRIPTION
Closes #142  

- Resizes the PRX logo to be smaller
- Adds a link to PRX.org
- NOTE: I chose not to go with the "X" because it lacks context and I think too easily confused with the app formerly known as Twitter, even if the style of the X is different.

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to [localhost:4300](http://localhost:4300).

> ...then...

- [ ] Note how the logo is smaller
- [ ] check responsive
- [ ] Click link
