### PR TITLE
147: Playlist thumbnails collapsing in Safari

### DIFF
--- a/components/Player/CoverArt/CoverArt.tsx
+++ b/components/Player/CoverArt/CoverArt.tsx
@@ -19,14 +19,14 @@ const CoverArt: React.FC<ICoverArtProps> = () => {
     togglePlayPause,
     imageUrl: defaultImageUrl
   } = useContext(PlayerContext);
-  const imageRef = useRef({ complete: false });
+  const imageRef = useRef<HTMLImageElement>(null);
   const isInitialLoad = useRef(true);
   const [isLoading, setIsLoading] = useState(false);
   const { tracks, currentTrackIndex } = state;
   const { imageUrl, title } = tracks[currentTrackIndex] || ({} as IAudioData);
   const srcUrl = imageUrl || defaultImageUrl;
   const rootClassNames = clsx(styles.root, {
-    [styles.loaded]: !isLoading || imageRef.current.complete
+    [styles.loaded]: !isLoading || imageRef.current?.complete
   });
 
   const handleClick = () => {

--- a/components/Player/PlayerThumbnail/PlayerThumbnail.tsx
+++ b/components/Player/PlayerThumbnail/PlayerThumbnail.tsx
@@ -23,7 +23,7 @@ const PlayerThumbnail: React.FC<IPlayerThumbnailProps> = ({
   height,
   ...props
 }) => {
-  const imageRef = useRef({ complete: false });
+  const imageRef = useRef<HTMLImageElement>(null);
   const isInitialLoad = useRef(true);
   const { state, imageUrl: defaultImageUrl } = useContext(PlayerContext);
   const [isLoading, setIsLoading] = useState(false);
@@ -31,7 +31,7 @@ const PlayerThumbnail: React.FC<IPlayerThumbnailProps> = ({
   const { imageUrl, title } = tracks[currentTrackIndex] || {};
   const srcUrl = imageUrl || defaultImageUrl;
   const rootClassNames = clsx(styles.root, className, {
-    [styles.loaded]: !isLoading || imageRef.current.complete
+    [styles.loaded]: !isLoading || imageRef.current?.complete
   });
 
   const handleLoad = useCallback(() => {

--- a/components/PrxImage/PrxImage.module.scss
+++ b/components/PrxImage/PrxImage.module.scss
@@ -4,12 +4,15 @@
   inset: 0;
   box-sizing: border-box;
   overflow: hidden;
+
+  & > .image {
+    position: absolute;
+    inset: 0;
+  }
 }
 
 .image {
   display: block;
-  position: absolute;
-  inset: 0;
   box-sizing: border-box;
   width: 0;
   height: 0;

--- a/components/PrxImage/PrxImage.tsx
+++ b/components/PrxImage/PrxImage.tsx
@@ -5,7 +5,7 @@
 
 import type React from 'react';
 import type { ImageProps } from 'next/image';
-import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { forwardRef } from 'react';
 import Image from 'next/image';
 import clsx from 'clsx';
 import isTrustedImageDomain from '@lib/validate/isTrustedImageDomain';
@@ -13,22 +13,18 @@ import styles from './PrxImage.module.scss';
 
 export interface IPrxImageProps extends ImageProps {}
 
-const PrxImage = forwardRef<{ complete: boolean }, IPrxImageProps>(
+const PrxImage = forwardRef<HTMLImageElement, IPrxImageProps>(
   ({ className, src, alt, fill, priority, onLoad, ...other }, ref) => {
-    const imageRef = useRef<HTMLImageElement>();
     const isUrlString = typeof src === 'string';
     const isTrusted = isUrlString && isTrustedImageDomain(src as string);
     const imageClassNames = clsx(className, styles.image);
     const nextImageProps = {
-      className: imageClassNames,
+      ref,
+      className,
       fill,
       priority,
       onLoad
     };
-
-    useImperativeHandle(ref, () => ({
-      complete: imageRef.current?.complete
-    }));
 
     if (!src) return null;
 
@@ -39,7 +35,7 @@ const PrxImage = forwardRef<{ complete: boolean }, IPrxImageProps>(
         <div className={styles.wrapper}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            ref={imageRef}
+            ref={ref}
             src={src as string}
             alt={alt}
             {...other}
@@ -50,7 +46,7 @@ const PrxImage = forwardRef<{ complete: boolean }, IPrxImageProps>(
       )) || (
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          ref={imageRef}
+          ref={ref}
           src={src as string}
           alt={alt}
           className={className}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,9 +2767,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587:
-  version "1.0.30001629"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz"
-  integrity sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==
+  version "1.0.30001632"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz"
+  integrity sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
Closes #147 

- fix images with blur transition defaulting to blurred in Safari
- forward ref as HTMLImageElement
- cover art component image ref
- player thumbnail component image ref

## To Review

- [x] Checkout Branch.
- [ ] Run `asdf install`.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [x] Go to http://localhost:4300/e?sp=all&uf=http%3A%2F%2Ffeeds.feedburner.com%2Fpri%2Ftheworld

> ...then...

- [x] Ensure playlist thumbnails are visible.
- [x] Ensure player thumbnail doesn't default to blurry.
- [x] Select another track with a different thumbnail.
- [x] Ensure player thumbnail transitions to clear image (may blur while loading if you had not loaded it before.)
- [x] Go to http://localhost:4300/e?sp=all&uf=http%3A%2F%2Ffeeds.feedburner.com%2Fpri%2Ftheworld&ca=1
- [x] Ensure cover art doesn't default to blurry.
- [x] Select another track with a different thumbnail.
- [x] Ensure cover art transitions to clear image (may blur while loading if you had not loaded it before.)
