### PR TITLE
127: Add download links to listen page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
     "clsx",
     "customsearch",
     "Denormalized",
+    "filesize",
     "flipboard",
     "Lede",
     "metatags",

--- a/components/IconButton/IconButton.tsx
+++ b/components/IconButton/IconButton.tsx
@@ -11,18 +11,19 @@ import styles from './IconButton.module.scss';
 export interface IIconButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   href?: string;
+  download?: boolean | string;
 }
 
 const IconButton = forwardRef<any, IIconButtonProps>(
-  ({ children, className = null, href = null, ...props }, ref) =>
+  ({ children, className = null, href = null, download, ...props }, ref) =>
     href ? (
       <a
         className={clsx(styles.iconButton, className)}
         href={href}
         rel="noreferrer"
-        target="_blank"
         ref={ref}
         title={props.title}
+        {...((download && { download }) || { target: '_blank' })}
       >
         {children}
       </a>

--- a/components/Listen/Episode/Episode.module.scss
+++ b/components/Listen/Episode/Episode.module.scss
@@ -72,8 +72,6 @@ $episode-breakpoint--full: 120ch;
     var(--episode-header-text-size--max)
   );
 
-  line-height: 1;
-
   &.isExplicit {
     grid-template-columns: 2em min-content 1fr;
   }

--- a/components/Listen/Episode/Episode.module.scss
+++ b/components/Listen/Episode/Episode.module.scss
@@ -33,6 +33,11 @@ $episode-breakpoint--full: 120ch;
 }
 
 .root {
+  --_episode-header-background-color: var(
+    --episode-header-background-color,
+    #{colors.$black-a-60}
+  );
+
   container-type: inline-size;
   container-name: episode-root;
   display: grid;
@@ -101,8 +106,6 @@ $episode-breakpoint--full: 120ch;
   overflow: hidden;
   overflow-y: auto;
 
-  outline: solid 1px white;
-
   padding-inline: 0;
 
   & > * {
@@ -122,21 +125,21 @@ $episode-breakpoint--full: 120ch;
 
 .header {
   --spacing: 0.25rem;
+  --iconButton--size: clamp(24px, 5vw, 40px);
 
   position: sticky;
-  top: 0;
-  display: grid;
+  top: 8px;
+  display: flex;
+  flex-wrap: wrap;
   z-index: 9;
   isolation: isolate;
-  grid-template-columns: auto min-content;
-  grid-auto-rows: min-content;
   justify-content: space-between;
   align-items: center;
-  gap: var(--gap);
-
-  border-bottom: var(--episode-divider-size) solid var(--episode-divider-color);
+  column-gap: var(--gap);
+  row-gap: calc(var(--gap) / 2);
 
   padding: var(--gap);
+  margin-inline: 8px;
 
   color: var(--episodeCard-footer-text-color);
   font-size: clamp(
@@ -152,18 +155,16 @@ $episode-breakpoint--full: 120ch;
     inset: 0;
     z-index: -1;
 
-    background-color: colors.$black-a-70;
-    backdrop-filter: blur(30px);
+    background-color: var(--_episode-header-background-color);
+    backdrop-filter: blur(15px);
+    border-radius: 5px;
   }
 
   @media (min-width: Listen.$breakpoint-full) {
     grid-row: 1;
     grid-column: 2;
-    grid-template-rows: none;
-    justify-content: space-between;
     align-self: center;
-
-    border-bottom: none;
+    top: 0;
 
     &::before {
       content: none;
@@ -201,7 +202,7 @@ $episode-breakpoint--full: 120ch;
 }
 
 .controls {
-  --iconButton--size: 60px;
+  --iconButton--size: clamp(40px, 5vw, 60px);
   --iconButton--padding: 0;
 }
 
@@ -228,11 +229,20 @@ $episode-breakpoint--full: 120ch;
 
 .menu {
   justify-self: end;
+  display: flex;
+  align-items: center;
+  column-gap: 4px;
 }
 
 .viewNav {
   display: flex;
   gap: 1rem;
+  width: 100%;
+
+  padding-top: calc(var(--gap) / 2);
+  margin-top: calc(var(--gap) / 2);
+
+  border-top: 1px solid var(--episode-divider-color);
 }
 
 .viewNavButton {
@@ -290,6 +300,7 @@ $episode-breakpoint--full: 120ch;
 
 .description {
   padding: var(--gap);
+  margin-inline: var(--gap);
 
   font-size: clamp(
     var(--episode-text-size--min),

--- a/components/Listen/Episode/Episode.tsx
+++ b/components/Listen/Episode/Episode.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@interfaces/data';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import clsx from 'clsx';
+import { filesize } from 'filesize';
 import Link from 'next/link';
 import HtmlContent from '@components/HtmlContent';
 import IconButton from '@components/IconButton';
@@ -24,6 +25,7 @@ import fetchAudioTranscriptData from '@lib/fetch/transcript/fetchAudioTranscript
 import formatDurationParts from '@lib/format/time/formatDurationParts';
 import sumDurationParts from '@lib/math/time/sumDurationParts';
 import ArrowLeftIcon from '@svg/icons/ArrowLeft.svg';
+import DownloadIcon from '@svg/icons/FileDownload.svg';
 import ExplicitIcon from '@svg/icons/Explicit.svg';
 import PlayCircleIcon from '@svg/icons/PlayCircle.svg';
 import PauseCircleIcon from '@svg/icons/PauseCircle.svg';
@@ -36,7 +38,7 @@ export interface IEpisodeProps {
 }
 
 const episodeViews = ['description', 'transcript'] as const;
-export type EpisodeView = typeof episodeViews[number];
+export type EpisodeView = (typeof episodeViews)[number];
 
 const Episode = ({ data, onClose }: IEpisodeProps) => {
   const [view, setView] = useState<EpisodeView>('description');
@@ -50,6 +52,8 @@ const Episode = ({ data, onClose }: IEpisodeProps) => {
   const {
     guid,
     title,
+    url,
+    fileSize,
     imageUrl,
     duration,
     explicit,
@@ -87,6 +91,7 @@ const Episode = ({ data, onClose }: IEpisodeProps) => {
   const episodesDurationSums = sumDurationParts([episodesDurationsInt]);
   const episodesDurationString = formatDurationParts(episodesDurationSums);
   const [shareShown, setShareShown] = useState(false);
+  const downloadTitle = `Download Episode (${filesize(fileSize || 0)})`;
 
   const handlePlayButtonClick = useCallback(() => {
     playTrack(index);
@@ -125,7 +130,7 @@ const Episode = ({ data, onClose }: IEpisodeProps) => {
       <ThemeVars theme="Episode" cssProps={styles} />
       <div className={styles.root} data-episode-view={view}>
         <div className={clsx(styles.nav, { [styles.isExplicit]: explicit })}>
-          <IconButton onClick={handleEpisodeBackClick}>
+          <IconButton onClick={handleEpisodeBackClick} title="Back To Playlist">
             <ArrowLeftIcon />
           </IconButton>
           {explicit && (
@@ -153,6 +158,7 @@ const Episode = ({ data, onClose }: IEpisodeProps) => {
                   <IconButton
                     className={styles.pause}
                     onClick={handlePauseButtonClick}
+                    title="Pause Episode"
                   >
                     <PauseCircleIcon />
                   </IconButton>
@@ -160,6 +166,7 @@ const Episode = ({ data, onClose }: IEpisodeProps) => {
                   <IconButton
                     className={styles.play}
                     onClick={handlePlayButtonClick}
+                    title="Play Episode"
                   >
                     <PlayCircleIcon />
                   </IconButton>
@@ -176,6 +183,10 @@ const Episode = ({ data, onClose }: IEpisodeProps) => {
               </span>
             </div>
             <div className={styles.menu}>
+              <IconButton href={url} title={downloadTitle} download>
+                <DownloadIcon aria-hidden />
+              </IconButton>
+
               <ShareMenu
                 className={clsx(styles.menuButton, styles.shareButton)}
                 onOpen={handleShareButtonClick}
@@ -192,6 +203,7 @@ const Episode = ({ data, onClose }: IEpisodeProps) => {
               <nav className={styles.viewNav}>
                 {episodeViews.map((viewName) => (
                   <Link
+                    className={styles.viewNavButton}
                     href={`#${viewName}`}
                     onClick={() => {
                       setView(viewName);

--- a/components/Listen/EpisodeList/EpisodeCard/EpisodeCard.module.scss
+++ b/components/Listen/EpisodeList/EpisodeCard/EpisodeCard.module.scss
@@ -390,11 +390,34 @@ $episodeCard-corner-radius: 5px;
   column-gap: var(--spacing);
 
   & > * {
+    display: flex;
+    align-items: center;
     white-space: nowrap;
 
     &::before {
       content: '\2022';
       margin-inline-end: var(--spacing);
     }
+  }
+}
+
+.downloadLink {
+  display: inline-flex;
+  align-items: center;
+  column-gap: 2px;
+
+  padding-inline-end: 3px;
+
+  border-radius: 3px;
+
+  svg {
+    width: 1.25em;
+    aspect-ratio: 1;
+    fill: currentColor;
+  }
+
+  &:where(:hover, :focus-visible) {
+    outline: none;
+    background-color: color-mix(in oklab, currentColor 20%, transparent);
   }
 }

--- a/components/Listen/EpisodeList/EpisodeCard/EpisodeCard.tsx
+++ b/components/Listen/EpisodeList/EpisodeCard/EpisodeCard.tsx
@@ -6,12 +6,15 @@
 import type { IListenEpisodeData } from '@interfaces/data';
 import { CSSProperties, useCallback, useContext, useMemo } from 'react';
 import clsx from 'clsx';
+import { filesize } from 'filesize';
+import Link from 'next/link';
 import IconButton from '@components/IconButton';
 import PrxImage from '@components/PrxImage';
 import PlayerContext from '@contexts/PlayerContext';
 import convertDurationStringToIntegerArray from '@lib/convert/string/convertDurationStringToIntegerArray';
 import sumDurationParts from '@lib/math/time/sumDurationParts';
 import formatDurationParts from '@lib/format/time/formatDurationParts';
+import DownloadIcon from '@svg/icons/FileDownload.svg';
 import ExplicitIcon from '@svg/icons/Explicit.svg';
 import PlayIcon from '@svg/icons/PlayArrow.svg';
 import PauseIcon from '@svg/icons/Pause.svg';
@@ -35,8 +38,17 @@ const EpisodeCard = ({ index, episode, onEpisodeClick }: IEpisodeCardProps) => {
   } = useContext(PlayerContext);
   const { currentTrackIndex, playing } = state;
   const isCurrentTrack = index === currentTrackIndex;
-  const { guid, title, subtitle, imageUrl, duration, explicit, pubDate } =
-    episode;
+  const {
+    guid,
+    title,
+    subtitle,
+    imageUrl,
+    duration,
+    explicit,
+    pubDate,
+    url,
+    fileSize
+  } = episode;
   const thumbSrc = imageUrl || defaultThumbUrl;
   const thumbnailSize = 100;
   const thumbnailSizeMobile = 40;
@@ -54,6 +66,7 @@ const EpisodeCard = ({ index, episode, onEpisodeClick }: IEpisodeCardProps) => {
   const episodesDurationsInt = convertDurationStringToIntegerArray(duration);
   const episodesDurationSums = sumDurationParts([episodesDurationsInt]);
   const episodesDurationString = formatDurationParts(episodesDurationSums);
+  const downloadLabel = filesize(fileSize);
 
   const handlePlayButtonClick = useCallback(() => {
     playTrack(index);
@@ -95,7 +108,7 @@ const EpisodeCard = ({ index, episode, onEpisodeClick }: IEpisodeCardProps) => {
                 <IconButton
                   className={styles.pause}
                   onClick={handlePauseButtonClick}
-                  title="Pause This Episode"
+                  title="Pause Episode"
                 >
                   <PauseIcon />
                 </IconButton>
@@ -103,7 +116,7 @@ const EpisodeCard = ({ index, episode, onEpisodeClick }: IEpisodeCardProps) => {
                 <IconButton
                   className={styles.play}
                   onClick={handlePlayButtonClick}
-                  title="Play This Episode"
+                  title="Play Episode"
                 >
                   <PlayIcon />
                 </IconButton>
@@ -130,7 +143,7 @@ const EpisodeCard = ({ index, episode, onEpisodeClick }: IEpisodeCardProps) => {
                 <IconButton
                   className={styles.pause}
                   onClick={handlePauseButtonClick}
-                  title="Pause This Episode"
+                  title="Pause Episode"
                 >
                   <PauseCircleIcon />
                 </IconButton>
@@ -138,7 +151,7 @@ const EpisodeCard = ({ index, episode, onEpisodeClick }: IEpisodeCardProps) => {
                 <IconButton
                   className={styles.play}
                   onClick={handlePlayButtonClick}
-                  title="Play This Episode"
+                  title="Play Episode"
                 >
                   <PlayCircleIcon />
                 </IconButton>
@@ -159,6 +172,17 @@ const EpisodeCard = ({ index, episode, onEpisodeClick }: IEpisodeCardProps) => {
                 <span className={styles.pubDate}>{pubDateFormatted}</span>
                 <span className={styles.duration}>
                   {episodesDurationString}
+                </span>
+                <span className={styles.download}>
+                  <Link
+                    className={styles.downloadLink}
+                    href={url}
+                    download
+                    title="Download Episode"
+                  >
+                    <DownloadIcon aria-hidden="true" />
+                    {downloadLabel}
+                  </Link>
                 </span>
               </div>
             </span>

--- a/components/Listen/EpisodeList/EpisodeList.module.scss
+++ b/components/Listen/EpisodeList/EpisodeList.module.scss
@@ -43,6 +43,10 @@ $episodeList-header-icon-color--active: colors.$white;
     --episodeList-header-icon-color--active,
     #{$episodeList-header-icon-color--active}
   );
+  --_episodeList-header-background-color: var(
+    --episodeList-header-background-color,
+    #{colors.$black-a-60}
+  );
 
   display: grid;
   grid-template-rows: min-content 1fr;
@@ -57,8 +61,9 @@ $episodeList-header-icon-color--active: colors.$white;
 }
 
 .header {
+  isolation: isolate;
   position: sticky;
-  top: 0;
+  top: 8px;
   z-index: 9;
   display: flex;
   justify-content: space-between;
@@ -67,22 +72,38 @@ $episodeList-header-icon-color--active: colors.$white;
 
   padding-block: 0.5rem;
   padding-inline: 1rem;
-
-  border-top-style: solid;
-  border-top-width: var(--_episodeList-divider-size);
-  border-top-color: var(--_episodeList-divider-color);
-
-  border-bottom-style: solid;
-  border-bottom-width: var(--_episodeList-divider-size);
-  border-bottom-color: var(--_episodeList-divider-color);
-
-  background-color: var(--listen-background-color, colors.$black-a-90);
+  margin-inline: 8px;
 
   font-size: clamp(0.75rem, 5vw, 1rem);
   font-weight: 700;
 
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+
+    background-color: var(--_episodeList-header-background-color);
+
+    backdrop-filter: blur(20px);
+
+    border-radius: 5px;
+  }
+
   @media (min-width: Listen.$breakpoint-full) {
-    background-color: transparent;
+    top: 0;
+
+    border-top-style: solid;
+    border-top-width: var(--_episodeList-divider-size);
+    border-top-color: var(--_episodeList-divider-color);
+
+    border-bottom-style: solid;
+    border-bottom-width: var(--_episodeList-divider-size);
+    border-bottom-color: var(--_episodeList-divider-color);
+
+    &::before {
+      content: unset;
+    }
   }
 }
 

--- a/components/Listen/FooterPlayer/FooterPlayer.module.scss
+++ b/components/Listen/FooterPlayer/FooterPlayer.module.scss
@@ -28,9 +28,9 @@ $footerPlayer-thumbnail-size--mobile: 24px;
   transform: translateY(100%);
   position: absolute;
   isolation: isolate;
-  left: 0;
-  bottom: 100%;
-  width: 100%;
+  left: 8px;
+  right: 8px;
+  bottom: calc(100% + 8px);
 
   display: grid;
   grid-template-columns: var(--footerPlayer-thumbnail-size--mobile) 1fr;
@@ -51,9 +51,11 @@ $footerPlayer-thumbnail-size--mobile: 24px;
     inset: 0;
     z-index: -1;
 
-    background-color: var(--footerPlayer-background-color, colors.$black);
+    background-color: var(--footerPlayer-background-color);
 
-    backdrop-filter: blur(30px);
+    backdrop-filter: blur(15px);
+
+    border-radius: 5px;
   }
 
   &.isShown {
@@ -166,7 +168,9 @@ $footerPlayer-thumbnail-size--mobile: 24px;
 
   background-color: var(--footerPlayer-background-color);
 
-  backdrop-filter: blur(30px);
+  backdrop-filter: blur(15px);
+
+  border-radius: 5px;
 
   color: var(--listen-text-color);
 }

--- a/components/Listen/FooterPlayer/FooterPlayer.tsx
+++ b/components/Listen/FooterPlayer/FooterPlayer.tsx
@@ -86,6 +86,18 @@ const FooterPlayer = forwardRef<HTMLDivElement, IFooterPlayerProps>(
             <div className={styles.title}>
               <Marquee>{title}</Marquee>
             </div>
+          </div>
+
+          <div className={styles.controls}>
+            {tracks.length > 1 && <PreviousButton />}
+            <ReplayButton />
+            <PlayButton />
+            <ForwardButton />
+            {tracks.length > 1 && <NextButton />}
+          </div>
+
+          <div className={styles.progress}>
+            <PlayerProgress />
 
             {showClosedCaptionsButton && (
               <ClosedCaptionsDialog
@@ -105,18 +117,7 @@ const FooterPlayer = forwardRef<HTMLDivElement, IFooterPlayerProps>(
                 <ClosedCaptionsFeed speakerColors={accentColor} />
               </ClosedCaptionsDialog>
             )}
-          </div>
 
-          <div className={styles.controls}>
-            {tracks.length > 1 && <PreviousButton />}
-            <ReplayButton />
-            <PlayButton />
-            <ForwardButton />
-            {tracks.length > 1 && <NextButton />}
-          </div>
-
-          <div className={styles.progress}>
-            <PlayerProgress />
             <Popover.Trigger asChild>
               <SettingsMenuButton />
             </Popover.Trigger>
@@ -124,7 +125,8 @@ const FooterPlayer = forwardRef<HTMLDivElement, IFooterPlayerProps>(
               side="top"
               sideOffset={8}
               align="end"
-              alignOffset={8}
+              alignOffset={0}
+              title="Settings"
             >
               <div className={styles.settingsMenu}>
                 <div className={styles.setting}>

--- a/components/Listen/Listen.module.scss
+++ b/components/Listen/Listen.module.scss
@@ -76,12 +76,14 @@ $viewTransitionDuration: 300ms;
     --episodeList-header-text-color: #{colors.$black};
     --episodeList-header-icon-color: #{colors.$black-a-30};
     --episodeList-header-icon-color--active: #{colors.$black};
+    --episodeList-header-background-color: #{colors.$white-a-60};
 
     // EpisodeCard
     --episodeCard-divider-color: #{colors.$black-a-20};
 
     // Episode
     --episode-divider-color: #{colors.$black-a-20};
+    --episode-header-background-color: #{colors.$white-a-60};
 
     // FooterPlayer
     --footerPlayer-background-color: #{colors.$white-a-60};
@@ -192,7 +194,7 @@ $viewTransitionDuration: 300ms;
       align-content: start;
       padding-block-start: 0.75rem;
       padding-block-end: calc(
-        var(--gutter-size-block-end, var(--gutter-size-block)) + 0.75rem
+        var(--gutter-size-block-end, var(--gutter-size-block)) + 1rem
       );
       padding-inline: 0;
       border-top: 1px solid $listen-divider-color;

--- a/components/Listen/Listen.tsx
+++ b/components/Listen/Listen.tsx
@@ -190,7 +190,10 @@ const Listen = ({ config, data }: IListenPageProps) => {
   };
 
   const handleResize = useCallback(() => {
-    setGutterBlockEnd(footerPlayerRef.current.getBoundingClientRect().height);
+    setGutterBlockEnd(
+      footerPlayerRef.current.parentElement.getBoundingClientRect().top -
+        footerPlayerRef.current.getBoundingClientRect().top
+    );
   }, []);
 
   const listenContextProps = useMemo(

--- a/components/Player/FileDownloadButton/FileDownloadButton.tsx
+++ b/components/Player/FileDownloadButton/FileDownloadButton.tsx
@@ -1,6 +1,6 @@
 /**
  * @file FileDownloadButton.tsx
- * Downlown MP3 Button for embed player and browser pages
+ * Download MP3 Button for embed player and browser pages
  */
 
 import type React from 'react';

--- a/interfaces/data/IAudioData.ts
+++ b/interfaces/data/IAudioData.ts
@@ -27,6 +27,11 @@ export interface IAudioData {
   url: string;
 
   /**
+   * File size audio file in bytes.
+   */
+  fileSize: number;
+
+  /**
    * Source URL for the preview audio file.
    * Should be used for playback when provided.
    * Do NOT include this in shared URL's or HTML markup.

--- a/lib/parse/data/parseAudioData.spec.ts
+++ b/lib/parse/data/parseAudioData.spec.ts
@@ -8,7 +8,8 @@ describe('lib/parse/data', () => {
       link: 'http://foo.com/foo-bar',
       title: 'foo',
       enclosure: {
-        url: 'http://foo.com/audio.mp3'
+        url: 'http://foo.com/audio.mp3',
+        length: 12345
       },
       categories: ['cat1', '  cat2', 'cat3   '],
       itunes: {
@@ -28,6 +29,7 @@ describe('lib/parse/data', () => {
         link: 'http://foo.com/foo-bar',
         title: 'foo',
         url: 'http://foo.com/audio.mp3?_from=play.prx.org',
+        fileSize: 12345,
         categories: ['cat1', 'cat2', 'cat3'],
         subtitle: 'bar',
         imageUrl: 'http://foo.com/image.png',
@@ -47,6 +49,7 @@ describe('lib/parse/data', () => {
         link: 'http://foo.com/foo-bar',
         title: 'foo',
         url: 'http://foo.com/audio.mp3?_from=play.prx.org',
+        fileSize: 12345,
         subtitle: 'bar',
         imageUrl: 'http://foo.com/image.png',
         season: 42,
@@ -65,6 +68,7 @@ describe('lib/parse/data', () => {
         link: 'http://foo.com/foo-bar',
         title: 'foo',
         url: 'http://foo.com/audio.mp3?_from=play.prx.org',
+        fileSize: 12345,
         categories: ['cat1', 'cat2', 'cat3']
       });
     });

--- a/lib/parse/data/parseAudioData.ts
+++ b/lib/parse/data/parseAudioData.ts
@@ -19,7 +19,10 @@ const parseAudioData = ({
 }: IRssItem): IAudioData => ({
   guid,
   ...(link && { link }),
-  ...(enclosure && { url: generateAudioUrl(enclosure.url) }),
+  ...(enclosure && {
+    url: generateAudioUrl(enclosure.url),
+    fileSize: enclosure.length
+  }),
   ...(categories && {
     categories: categories.map((v) => v.replace(/^\s+|\s+$/g, ''))
   }),

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@svgr/webpack": "^6.2.1",
     "clsx": "^1.1.1",
     "copy-to-clipboard": "^3.3.1",
+    "filesize": "^10.1.4",
     "framer-motion": "^11.1.9",
     "htmlparser2": "^8.0.1",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,9 +2905,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587:
-  version "1.0.30001649"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz"
-  integrity sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==
+  version "1.0.30001651"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz"
+  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -4080,6 +4080,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+filesize@^10.1.4:
+  version "10.1.4"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-10.1.4.tgz#184f256063a201f08b6e6b3cc47d21b60f5b8d89"
+  integrity sha512-ryBwPIIeErmxgPnm6cbESAzXjuEFubs+yKYLBZvg3CaiNcmkJChoOGcBSrZ6IwkMwPABwPpVXE6IlNdGJJrvEg==
 
 fill-range@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
Closes #127
Closes #155 

- add download link to playlist items
- add download link to episode header
- fix clipping of title text on episode view
- add fileSize to audio data
- add download prop to icon button component
- move cc button between progress bar and settings button
- improve layout of floating elements:
  - player
  - mobile playlist header
  - mobile episode header

## To Review

- [x] Checkout Branch.
- [x] Run `asdf install`.
- [x] Run `yarn`.
- [x] Run `yarn dev`.
- [ ] Go to http://localhost:4300/listen?uf=https%3A%2F%2Fpublicfeeds.net%2Ff%2F5043%2Ffeed-rss.xml

> ...then...

- [x] Ensure download link on playlist items downloads file when clicked.
- [x] Click title of an episode.
- [x] Ensure download link on episode view downloads file when clicked.
- [x] Resize window to mobile width. Ensure episode header content resizes responsively and no longer overflows right edge on really thin mobile sizes (Galaxy Z Fold candy bar size).
- [x] Go to http://localhost:4300/listen?uf=https%3A%2F%2Fkala.farski.com%2Fearhustlesq.xml&ac=EBCF00&ge=prx_59_df430720-ef2b-4648-8d6c-2060e7efbe6c
- [x] Note CC button moved to menu next to progress bar.
- [ ] Ensure episode header with nav links on episode with transcripts looks good.
- [ ] Go to http://localhost:4300/listen?uf=http%3A%2F%2Ffeeds.kera.org%2FKERA-Think&ge=prx_140_2c648e10-5980-48ab-8332-9045853db9fe
- [ ] Ensure title in top bar is no longer clipping.
