### PR TITLE
159: Update SRT transcript detection to include `application/x-subrip` content type

### DIFF
--- a/components/Player/Player.tsx
+++ b/components/Player/Player.tsx
@@ -58,7 +58,7 @@ const Player: React.FC<IPlayerProps> = ({
   const { url, previewUrl, transcripts, duration } = currentTrack;
   const currentTrackUrl = previewUrl || url;
   const transcript = transcripts?.find(
-    (t) => !!['vtt', 'srt', 'json'].find((n) => t.type.includes(n))
+    (t) => !!['vtt', 'srt', 'x-subrip', 'json'].find((n) => t.type.includes(n))
   );
 
   const boundedTime = useCallback(

--- a/pages/api/proxy/transcript/index.ts
+++ b/pages/api/proxy/transcript/index.ts
@@ -61,7 +61,8 @@ export default async function handler(
       },
       {
         check: (ct: string, t: string) =>
-          /(?:application|text)\/srt/i.test(ct) || t.includes('-->'),
+          /(?:application|text)\/(?:srt|x-subrip)/i.test(ct) ||
+          t.includes('-->'),
         convert: (t: string) => convertVttToJson(convertSrtToVtt(t))
       }
     ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,9 +2905,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587:
-  version "1.0.30001651"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz"
-  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
+  version "1.0.30001667"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz"
+  integrity sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
Closes #159 

- add `x-subrip` to srt detection in transcript proxy
- add `x-subrip` to srt conversion check in Player

## To Review

- [ ] Use the preview deployment: LINK_HERE

> ...or...

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to http://localhost:4300/listen?uf=https%3A%2F%2Fmedia.rss.com%2Fjames-cridland%2Ffeed.xml

> ...then...

- [ ] Ensure CC buttons are shown and function as expected.
- [ ] Repeat for http://localhost:4300/e?uf=https%3A%2F%2Fmedia.rss.com%2Fjames-cridland%2Ffeed.xml
