### PR TITLE
Set KEEP_ALIVE_TIMEOUT to 10 seconds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,5 +57,6 @@ USER nextjs
 EXPOSE 4300
 
 ENV PORT 4300
+ENV KEEP_ALIVE_TIMEOUT 10000
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
Increases the `keepAliveTimeout` of the Node server to 10 seconds (up from default of 5 seconds). Hopefully this will prevent so many of the `ECONNRESET` errors we have been seeing.

## To Review

- [ ] Code Review
