### PR TITLE
config(next): add cache-control header w/ max-age to listen route

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,7 +29,7 @@ const nextConfig = {
   async headers() {
     return [
       {
-        source: '/e',
+        source: '/:path(e|embed|listen)',
         headers: [
           {
             key: 'Cache-Control',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2917,9 +2917,9 @@ camelize@^1.0.0:
   integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
 
 caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587:
-  version "1.0.30001687"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz"
-  integrity sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==
+  version "1.0.30001689"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz"
+  integrity sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
- adds Cache-Control headers to `/listen' route that match those used on `/e` route.

## To Review

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn build`.
- [ ] Run `yarn start`.
- [ ] Go to http://localhost:4300/listen?uf=https://publicfeeds.net/f/380/feed-rss.xml

> ...then...

- [ ] Inspect response headers and ensure they include `cache-control: public, max-age=300`.
