### PR TITLE
fix(index): add closing iframe tag to documentation page

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -85,7 +85,7 @@ const Home: NextPage = () => {
   src="https://play.prx.org/e?uf=https://example.com/rss/feed.xml"
   width="100%"
   height="200"
-/>`}
+></iframe>`}
             </code>
           </pre>
           <p>
@@ -290,7 +290,7 @@ const Home: NextPage = () => {
   <iframe
     src="...&ca=1"
     style="position: absolute; inset: 0;"
-  />
+  ></iframe>
 </div>`}
             </code>
           </pre>
@@ -306,7 +306,7 @@ const Home: NextPage = () => {
   <iframe
     src="...&ca=1"
     style="position: absolute; inset: 0;"
-  />
+  ></iframe>
 </div>`}
             </code>
           </pre>
@@ -377,7 +377,7 @@ const Home: NextPage = () => {
   src="https://play.prx.org/e?uf=https://example.com/rss/feed.xml"
   width="100%"
   height="200"
-/>`}
+></iframe>`}
             </code>
           </pre>
           <h3>Card Style RSS Player</h3>
@@ -388,7 +388,7 @@ const Home: NextPage = () => {
   src="https://play.prx.org/e?uf=https://example.com/rss/feed.xml&ca=1"
   width="500"
   height="700"
-/>`}
+></iframe>`}
             </code>
           </pre>
           <h4>Responsive</h4>
@@ -398,7 +398,7 @@ const Home: NextPage = () => {
   <iframe
     src="https://play.prx.org/e?uf=https://example.com/rss/feed.xml&ca=1"
     style="position: absolute; inset: 0;"
-  />
+  ></iframe>
 </div>`}
             </code>
           </pre>
@@ -409,7 +409,7 @@ const Home: NextPage = () => {
   src="https://play.prx.org/e?uf=https://example.com/rss/feed.xml&sp=20"
   width="100%"
   height="600"
-/>`}
+></iframe>`}
             </code>
           </pre>
           <h3>Basic Audio File Player</h3>
@@ -419,7 +419,7 @@ const Home: NextPage = () => {
   src="https://play.prx.org/e?ua=https://example.com/files/audio.mp3&tt=My+Audio&ts+Something+about+the+audio%ue=https://example.com/files/thumbnail.jpg&ui=https://example.com/files/background.jpg"
   width="100%"
   height="200"
-/>`}
+></iframe>`}
             </code>
           </pre>
         </div>


### PR DESCRIPTION
- A user wrote into help desk noting our documentation needed closing iframe tags. Iframes can't be self closing.

## To Review

- [ ] Use the preview deployment: LINK_HERE

> ...or...

- [ ] Checkout Branch.
- [ ] Run `asdf install`.
- [ ] Run `yarn`.
- [ ] Run `yarn dev`.
- [ ] Go to [localhost:4300](http://localhost:4300).

> ...then...

- [ ] go to index page ensure proper text.
